### PR TITLE
WIP: Look up map descriptor by fd rather than using bits

### DIFF
--- a/src/asm_files.cpp
+++ b/src/asm_files.cpp
@@ -30,8 +30,16 @@ int create_map_crab(uint32_t map_type, uint32_t key_size, uint32_t value_size, u
     return (value_size << 14) + (key_size << 6); // + i;
 }
 
-vector<raw_program> read_elf(const std::string& path, const std::string& desired_section, ebpf_alloc_map_fd_fn fd_alloc, const ebpf_verifier_options_t* options, const ebpf_platform_t* platform) {
-    assert(fd_alloc != nullptr);
+EbpfMapDescriptor* find_map_descriptor(int map_fd) {
+    for (EbpfMapDescriptor& map : global_program_info.map_descriptors) {
+        if (map.original_fd == map_fd) {
+            return &map;
+        }
+    }
+    return nullptr;
+}
+
+vector<raw_program> read_elf(const std::string& path, const std::string& desired_section, const ebpf_verifier_options_t* options, const ebpf_platform_t* platform) {
     if (options == nullptr)
         options = &ebpf_verifier_default_options;
     ELFIO::elfio reader;
@@ -43,7 +51,7 @@ vector<raw_program> read_elf(const std::string& path, const std::string& desired
 
     ELFIO::section* maps_section = reader.sections["maps"];
     if (maps_section) {
-        platform->parse_maps_section(info.map_descriptors, maps_section->get_data(), maps_section->get_size(), fd_alloc, *options);
+        platform->parse_maps_section(info.map_descriptors, maps_section->get_data(), maps_section->get_size(), platform->create_map, *options);
     }
 
     ELFIO::const_symbol_section_accessor symbols{reader, reader.sections[".symtab"]};
@@ -96,18 +104,12 @@ vector<raw_program> read_elf(const std::string& path, const std::string& desired
                     ebpf_inst& inst = prog.prog[offset / sizeof(ebpf_inst)];
                     inst.src = 1; // magic number for LoadFd
 
-                    // if (fd_alloc == allocate_fds) {
-                    //     std::cout << read_reloc_value(symbol) << "=" <<
-                    //     info.map_descriptors[updated_fds.at(read_reloc_value(symbol))].value_size << "\n";
-                    //     inst.imm = updated_fds.at(read_reloc_value(symbol));
-                    // } else {
                     size_t reloc_value = read_reloc_value(symbol);
                     if (reloc_value >= info.map_descriptors.size()) {
                         throw std::runtime_error(string("Bad reloc value (") + std::to_string(reloc_value) + "). "
                                                  + "Make sure to compile with -O2.");
                     }
                     inst.imm = info.map_descriptors.at(reloc_value).original_fd;
-                    // }
                 }
             }
         }

--- a/src/asm_files.hpp
+++ b/src/asm_files.hpp
@@ -10,7 +10,7 @@
 #include "platform.hpp"
 
 std::vector<raw_program> read_raw(std::string path, program_info info);
-std::vector<raw_program> read_elf(const std::string& path, const std::string& section, ebpf_alloc_map_fd_fn alloc_map_fd, const ebpf_verifier_options_t* options, const ebpf_platform_t* platform);
+std::vector<raw_program> read_elf(const std::string& path, const std::string& section, const ebpf_verifier_options_t* options, const ebpf_platform_t* platform);
 
 void write_binary_file(std::string path, const char* data, size_t size);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -6,5 +6,6 @@
 const ebpf_verifier_options_t ebpf_verifier_default_options = {
     .check_termination = false,
     .print_invariants = false,
-    .print_failures = false
+    .print_failures = false,
+    .mock_map_fds = true,
 };

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -6,6 +6,9 @@ struct ebpf_verifier_options_t {
     bool check_termination;
     bool print_invariants;
     bool print_failures;
+
+    // False to use actual map fd's, true to use mock fd's.
+    bool mock_map_fds;
 };
 
 extern const ebpf_verifier_options_t ebpf_verifier_default_options;

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -23,10 +23,10 @@
 #include "crab/split_dbm.hpp"
 
 #include "asm_ostream.hpp"
-#include "config.hpp"
+#include "crab_verifier.hpp"
 #include "dsl_syntax.hpp"
 #include "helpers.hpp"
-#include "spec_type_descriptors.hpp"
+#include "platform.hpp"
 
 #include "crab/array_domain.hpp"
 
@@ -489,11 +489,17 @@ class ebpf_domain_t final {
     void operator()(const ValidMapKeyValue& s) {
         using namespace dsl_syntax;
 
+        // Get the actual map_fd value to look up the key size and value size.
         auto fd_reg = reg_pack(s.map_fd_reg);
-        apply(m_inv, crab::bitwise_binop_t::LSHR, variable_t::map_value_size(), fd_reg.value, (number_t)14);
-        variable_t mk = variable_t::map_key_size();
-        apply(m_inv, crab::arith_binop_t::UREM, mk, fd_reg.value, (number_t)(1 << 14));
-        lshr(mk, 6);
+        interval_t fd_interval = operator[](fd_reg.value);
+        std::optional<number_t> fd_opt = fd_interval.singleton();
+        if (!fd_opt.has_value()) {
+            throw std::runtime_error(std::string("map_fd is not a singleton"));
+        }
+        number_t map_fd = *fd_opt;
+        EbpfMapDescriptor& map_descriptor = global_program_info.platform->get_map_descriptor((int)map_fd);
+        m_inv.assign(variable_t::map_value_size(), (int)map_descriptor.value_size);
+        m_inv.assign(variable_t::map_key_size(), (int)map_descriptor.key_size);
 
         auto access_reg = reg_pack(s.access_reg);
 
@@ -1060,7 +1066,7 @@ class ebpf_domain_t final {
         if (dom.is_bottom()) {
             o << "_|_";
         } else {
-            o << dom.m_inv << "\n" << dom.stack;
+            o << "Invariants: " << dom.m_inv << "\nStack: " << dom.stack;
         }
         return o;
     }

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -9,3 +9,5 @@
 bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options);
 
 int create_map_crab(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
+
+EbpfMapDescriptor* find_map_descriptor(int map_fd);

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -94,12 +94,14 @@ int main(int argc, char** argv) {
     }
 #endif
 
-    auto create_map = domain == "linux" ? create_map_linux : create_map_crab;
+    if (domain == "linux")
+        ebpf_verifier_options.mock_map_fds = false;
+    const ebpf_platform_t* platform = &g_ebpf_platform_linux;
 
     // Read a set of raw program sections from an ELF file.
     vector<raw_program> raw_progs;
     try {
-        raw_progs = read_elf(filename, desired_section, create_map, &ebpf_verifier_options, &g_ebpf_platform_linux);
+        raw_progs = read_elf(filename, desired_section, &ebpf_verifier_options, platform);
     } catch (std::runtime_error e) {
         std::cerr << "error: " << e.what() << std::endl;
         return 1;
@@ -113,7 +115,7 @@ int main(int argc, char** argv) {
         if (!desired_section.empty() && raw_progs.size() == 0) {
             // We could not find the desired section, so get the full list
             // of possibilities.
-            raw_progs = read_elf(filename, string(), create_map, &ebpf_verifier_options, &g_ebpf_platform_linux);
+            raw_progs = read_elf(filename, string(), &ebpf_verifier_options, platform);
         }
         for (const raw_program& raw_prog : raw_progs) {
             std::cout << raw_prog.section << " ";

--- a/src/main/linux_verifier.cpp
+++ b/src/main/linux_verifier.cpp
@@ -14,34 +14,6 @@
 
 static int do_bpf(bpf_cmd cmd, union bpf_attr& attr) { return syscall(321, cmd, &attr, sizeof(attr)); }
 
-/** Try to allocate a Linux map.
- *
- *  This function requires admin privileges.
- */
-int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options) {
-    union bpf_attr attr{};
-    memset(&attr, '\0', sizeof(attr));
-    attr.map_type = map_type;
-    attr.key_size = key_size;
-    attr.value_size = value_size;
-    attr.max_entries = 20;
-    attr.map_flags = map_type == BPF_MAP_TYPE_HASH ? BPF_F_NO_PREALLOC : 0;
-    int map_fd = do_bpf(BPF_MAP_CREATE, attr);
-    if (map_fd < 0) {
-        if (options.print_failures) {
-            std::cerr << "Failed to create map, " << strerror(errno) << "\n";
-            std::cerr << "Map: \n"
-                      << " map_type = " << attr.map_type << "\n"
-                      << " key_size = " << attr.key_size << "\n"
-                      << " value_size = " << attr.value_size << "\n"
-                      << " max_entries = " << attr.max_entries << "\n"
-                      << " map_flags = " << attr.map_flags << "\n";
-        }
-        exit(2);
-    }
-    return map_fd;
-}
-
 /** Run the built-in Linux verifier on a raw eBPF program.
  *
  *  \return A pair (passed, elapsec_secs)

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -17,11 +17,13 @@ typedef EbpfHelperPrototype (*ebpf_get_helper_prototype_fn)(unsigned int n);
 typedef bool (*ebpf_is_helper_usable_fn)(unsigned int n);
 
 // Return an fd for a map created with the given parameters.
-typedef int (*ebpf_alloc_map_fd_fn)(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
+typedef int (*ebpf_create_map_fn)(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
 
 // Parse map records and allocate map fd's.
 // In the future we may want to move map fd allocation after the verifier step.
-typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t size, ebpf_alloc_map_fd_fn fd_alloc, ebpf_verifier_options_t options);
+typedef void (*ebpf_parse_maps_section_fn)(std::vector<EbpfMapDescriptor>& map_descriptors, const char* data, size_t size, ebpf_create_map_fn create_map, ebpf_verifier_options_t options);
+
+typedef EbpfMapDescriptor& (*ebpf_get_map_descriptor_fn)(int map_fd);
 
 struct ebpf_platform_t {
     ebpf_get_program_type_fn get_program_type;
@@ -32,6 +34,8 @@ struct ebpf_platform_t {
     size_t map_record_size;
 
     ebpf_parse_maps_section_fn parse_maps_section;
+    ebpf_create_map_fn create_map;
+    ebpf_get_map_descriptor_fn get_map_descriptor;
 };
 
 extern const ebpf_platform_t g_ebpf_platform_linux;

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -6,7 +6,7 @@
 #define FAIL_LOAD_ELF(dirname, filename, sectionname) \
     TEST_CASE("Try loading nonexisting program: " dirname "/" filename, "[elf]") { \
         try { \
-            read_elf("ebpf-samples/" dirname "/" filename, sectionname, create_map_crab, nullptr, &g_ebpf_platform_linux); \
+            read_elf("ebpf-samples/" dirname "/" filename, sectionname, nullptr, &g_ebpf_platform_linux); \
             REQUIRE(false); \
         } catch (const std::runtime_error&) { \
         }\
@@ -19,7 +19,7 @@ FAIL_LOAD_ELF("cilium", "bpf_lxc.o", "not-found")
 
 #define VERIFY_SECTION(dirname, filename, sectionname, pass) \
     do { \
-        auto raw_progs = read_elf("ebpf-samples/" dirname "/" filename, sectionname, create_map_crab, nullptr, &g_ebpf_platform_linux); \
+        auto raw_progs = read_elf("ebpf-samples/" dirname "/" filename, sectionname, nullptr, &g_ebpf_platform_linux); \
         REQUIRE(raw_progs.size() == 1); \
         raw_program raw_prog = raw_progs.back(); \
         std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, &g_ebpf_platform_linux); \


### PR DESCRIPTION
This lets the code work with either a mock fd like create_map_crab uses or an actual fd, without needing to know the difference since the map_descriptors are stored in the program_info.

create_map_linux() is moved from src/main/linux_verifier.cpp to src/linux/linux_platform.cpp to allow for the possibility of using the prevail verifier on an ebpf program that has real fd's in it, i.e., creating real maps but then just calling the prevail verifier instead of the linux verifier.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>