### PR TITLE
Make error messages be more readable by ebpf program developers

### DIFF
--- a/src/asm_ostream.hpp
+++ b/src/asm_ostream.hpp
@@ -15,7 +15,7 @@ inline std::function<int16_t(label_t)> label_to_offset(pc_t pc) {
     return [=](const label_t& label) { return label.from - pc - 1; };
 }
 
-void print(const InstructionSeq& prog, std::ostream& out);
+void print(const InstructionSeq& insts, std::ostream& out, std::optional<const label_t> label_to_print);
 void print(const InstructionSeq& insts, const std::string& outfile);
 
 std::string to_string(label_t const& label);

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -217,7 +217,7 @@ struct Assume {
 enum { T_UNINIT = -6, T_MAP = -5, T_NUM = -4, T_CTX = -3, T_STACK = -2, T_PACKET = -1, T_SHARED = 0 };
 
 enum class TypeGroup {
-    num,
+    number,
     map_fd,
     ctx,            ///< pointer to the special memory region named 'ctx'
     packet,         ///< pointer to the packet
@@ -226,7 +226,7 @@ enum class TypeGroup {
     non_map_fd,     // reg >= T_NUM
     mem,            // shared | packet | stack = reg >= T_STACK
     mem_or_num,     // reg >= T_NUM && reg != T_CTX
-    ptr,            // reg >= T_CTX
+    pointer,        // reg >= T_CTX
     ptr_or_num,     // reg >= T_NUM
     stack_or_packet // reg >= T_STACK && reg <= T_PACKET
 };

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -37,7 +37,7 @@ class AssertExtractor {
     vector<Assert> operator()(Packet const& ins) const { return {Assert{TypeConstraint{Reg{6}, TypeGroup::ctx}}}; }
 
     /// Verify that Exit returns a number.
-    vector<Assert> operator()(Exit const& e) const { return {Assert{TypeConstraint{Reg{R0_RETURN_VALUE}, TypeGroup::num}}}; }
+    vector<Assert> operator()(Exit const& e) const { return {Assert{TypeConstraint{Reg{R0_RETURN_VALUE}, TypeGroup::number}}}; }
 
     vector<Assert> operator()(Call const& call) const {
         vector<Assert> res;
@@ -47,7 +47,7 @@ class AssertExtractor {
             case ArgSingle::Kind::ANYTHING:
                 // avoid pointer leakage:
                 if (!info.type.is_privileged) {
-                    res.emplace_back(TypeConstraint{arg.reg, TypeGroup::num});
+                    res.emplace_back(TypeConstraint{arg.reg, TypeGroup::number});
                 }
                 break;
             case ArgSingle::Kind::MAP_FD:
@@ -83,7 +83,7 @@ class AssertExtractor {
                 break;
             }
             // TODO: reg is constant (or maybe it's not important)
-            res.emplace_back(TypeConstraint{arg.size, TypeGroup::num});
+            res.emplace_back(TypeConstraint{arg.size, TypeGroup::number});
             res.emplace_back(ValidSize{arg.size, arg.can_be_zero});
             res.emplace_back(ValidAccess{arg.mem, 0, arg.size,
                                          arg.kind == ArgPair::Kind::PTR_TO_MEM_OR_NULL});
@@ -99,7 +99,7 @@ class AssertExtractor {
         res.emplace_back(ValidAccess{cond.left});
         if (std::holds_alternative<Imm>(cond.right)) {
             if (imm(cond.right).v != 0) {
-                res.emplace_back(TypeConstraint{cond.left, TypeGroup::num});
+                res.emplace_back(TypeConstraint{cond.left, TypeGroup::number});
             } else {
                 // OK - map_fd is just another pointer
                 // Anything can be compared to 0
@@ -131,11 +131,11 @@ class AssertExtractor {
             // We know we are accessing the stack.
             res.emplace_back(ValidAccess{basereg, offset, width, false});
         } else {
-            res.emplace_back(TypeConstraint{basereg, TypeGroup::ptr});
+            res.emplace_back(TypeConstraint{basereg, TypeGroup::pointer});
             res.emplace_back(ValidAccess{basereg, offset, width, false});
             if (!info.type.is_privileged && !ins.is_load && std::holds_alternative<Reg>(ins.value)) {
                 if (width.v != 8)
-                    res.emplace_back(TypeConstraint{reg(ins.value), TypeGroup::num});
+                    res.emplace_back(TypeConstraint{reg(ins.value), TypeGroup::number});
                 else
                     res.emplace_back(ValidStore{ins.access.basereg, reg(ins.value)});
             }
@@ -173,7 +173,7 @@ class AssertExtractor {
             }
             return {};
         default:
-            return { Assert{TypeConstraint{ins.dst, TypeGroup::num}} };
+            return { Assert{TypeConstraint{ins.dst, TypeGroup::number}} };
         }
     }
 };

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -6,5 +6,6 @@
 const ebpf_verifier_options_t ebpf_verifier_default_options = {
     .check_termination = false,
     .print_invariants = false,
-    .print_failures = false
+    .print_failures = false,
+    .no_simplify = false
 };

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -6,6 +6,7 @@ struct ebpf_verifier_options_t {
     bool check_termination;
     bool print_invariants;
     bool print_failures;
+    bool no_simplify;
 };
 
 extern const ebpf_verifier_options_t ebpf_verifier_default_options;

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -569,7 +569,7 @@ class ebpf_domain_t final {
     NumAbsDomain check_access_stack(NumAbsDomain inv, const linear_expression_t& lb, const linear_expression_t& ub, const std::string& s) {
         using namespace dsl_syntax;
         require(inv, lb >= 0, std::string("Lower bound must be higher than 0") + s);
-        require(inv, ub <= EBPF_STACK_SIZE, std::string("Upper bound must be lower than EBPF_STACK_SIZE") + s);
+        require(inv, ub <= EBPF_STACK_SIZE, std::string("Upper bound must be lower than EBPF_STACK_SIZE") + s + std::string(", make sure to bounds check any pointer access"));
         return inv;
     }
 
@@ -607,7 +607,7 @@ class ebpf_domain_t final {
         variable_t t = reg_pack(s.reg).type;
         std::string str = to_string(s);
         switch (s.types) {
-        case TypeGroup::num: require(m_inv, t == T_NUM, str); break;
+        case TypeGroup::number: require(m_inv, t == T_NUM, str); break;
         case TypeGroup::map_fd: require(m_inv, t == T_MAP, str); break;
         case TypeGroup::ctx: require(m_inv, t == T_CTX, str); break;
         case TypeGroup::packet: require(m_inv, t == T_PACKET, str); break;
@@ -619,7 +619,7 @@ class ebpf_domain_t final {
             require(m_inv, t >= T_NUM, str);
             require(m_inv, t != T_CTX, str);
             break;
-        case TypeGroup::ptr: require(m_inv, t >= T_CTX, str); break;
+        case TypeGroup::pointer: require(m_inv, t >= T_CTX, str); break;
         case TypeGroup::ptr_or_num: require(m_inv, t >= T_NUM, str); break;
         case TypeGroup::stack_or_packet:
             require(m_inv, t >= T_STACK, str);
@@ -1060,7 +1060,7 @@ class ebpf_domain_t final {
         if (dom.is_bottom()) {
             o << "_|_";
         } else {
-            o << dom.m_inv << "\n" << dom.stack;
+            o << dom.m_inv << "\nStack: " << dom.stack;
         }
         return o;
     }

--- a/src/crab/split_dbm.cpp
+++ b/src/crab/split_dbm.cpp
@@ -1217,10 +1217,19 @@ std::ostream& operator<<(std::ostream& o, SplitDBM& dom) {
             first = false;
         else
             o << ", ";
-        o << *(dom.rev_map[v]) << " -> ";
-        if (v_out.lb() == v_out.ub())
-            o << "[" << v_out.lb() << "]";
-        else
+        variable_t variable = *(dom.rev_map[v]);
+        o << variable << "=";
+        if (v_out.lb() == v_out.ub()) {
+            if (variable.is_type()) {
+                static const char* type_string[] = {"shared_pointer", "packet_pointer", "stack_pointer", "ctx_pointer", "number", "map_fd", "uninitialized"};
+                int type = (int)v_out.lb().number().value();
+                if (type <= 0 && type > -std::size(type_string))
+                    o << type_string[-type];
+                else
+                    o << "map_value_of_size(" << v_out.lb() << ")";
+            } else
+                o << "[" << v_out.lb() << "]";
+        } else
             o << v_out;
     }
     if (!first) o << "\n ";

--- a/src/crab/var_factory.cpp
+++ b/src/crab/var_factory.cpp
@@ -18,31 +18,33 @@ variable_t variable_t::make(const std::string& name) {
     }
 }
 
-std::vector<std::string> variable_t::names{"r0",          "off0",      "t0",
-                                           "r1",          "off1",      "t1",
-                                           "r2",          "off2",      "t2",
-                                           "r3",          "off3",      "t3",
-                                           "r4",          "off4",      "t4",
-                                           "r5",          "off5",      "t5",
-                                           "r6",          "off6",      "t6",
-                                           "r7",          "off7",      "t7",
-                                           "r8",          "off8",      "t8",
-                                           "r9",          "off9",      "t9",
-                                           "r10",         "off10",     "t10",
-                                           "S_r",         "S_off",     "S_t",
-                                           "data_size",   "meta_size", "map_value_size",
-                                           "map_key_size"};
+std::vector<std::string> variable_t::names{
+    "r0.value",    "r0.offset",  "r0.type",
+    "r1.value",    "r1.offset",  "r1.type",
+    "r2.value",    "r2.offset",  "r2.type",
+    "r3.value",    "r3.offset",  "r3.type",
+    "r4.value",    "r4.offset",  "r4.type",
+    "r5.value",    "r5.offset",  "r5.type",
+    "r6.value",    "r6.offset",  "r6.type",
+    "r7.value",    "r7.offset",  "r7.type",
+    "r8.value",    "r8.offset",  "r8.type",
+    "r9.value",    "r9.offset",  "r9.type",
+    "r10.value",   "r10.offset", "r10.type",
+    "S.value",     "S.offset",   "S.type",
+    "data_size",   "meta_size",  "map_value_size",
+    "map_key_size"};
 
 static std::string name_of(data_kind_t kind) {
     switch (kind) {
-    case data_kind_t::offsets: return "off";
-    case data_kind_t::values: return "r";
-    case data_kind_t::types: return "t";
+    case data_kind_t::offsets: return "offset";
+    case data_kind_t::values: return "value";
+    case data_kind_t::types: return "type";
     }
     return {};
 }
 
-variable_t variable_t::reg(data_kind_t kind, int i) { return make(name_of(kind) + std::to_string(i)); }
+variable_t variable_t::reg(data_kind_t kind, int i) {
+    return make("r" + std::to_string(i) + "." + name_of(kind)); }
 
 std::ostream& operator<<(std::ostream& o, const data_kind_t& s) {
     return o << name_of(s);
@@ -50,7 +52,7 @@ std::ostream& operator<<(std::ostream& o, const data_kind_t& s) {
 
 static std::string mk_scalar_name(data_kind_t kind, int o, int size) {
     std::stringstream os;
-    os << "S_" << name_of(kind) << "[" << o;
+    os << "S." << name_of(kind) << "[" << o;
     if (size != 1) {
         os << "..." << o + size - 1;
     }

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -41,6 +41,8 @@ class variable_t final {
 
     [[nodiscard]] std::string name() const { return names.at(_id); }
 
+    bool is_type() { return names.at(_id).find(".type") != std::string::npos; }
+
     friend std::ostream& operator<<(std::ostream& o, variable_t v)  { return o << names.at(v._id); }
 
     // var_factory portion.

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -8,4 +8,6 @@
 
 bool run_ebpf_analysis(std::ostream& s, cfg_t& cfg, program_info info, const ebpf_verifier_options_t* options);
 
+bool ebpf_verify_program(std::ostream& s, const InstructionSeq& prog, program_info info, const ebpf_verifier_options_t* options);
+
 int create_map_crab(uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);


### PR DESCRIPTION
I used https://sysdig.com/blog/the-art-of-writing-ebpf-programs-a-primer/ as various cases to improve the error messages, with a goal to make them at least as useful as the error messages shown in that walkthrough, for the same code.   This included, among a couple of other minor tweaks:

* Display instruction when showing a failure with a label that is an instruction
* Make invariants be readable, as in "assertion failed: r1 is pointer".  Example:
```
1: r1 = *(u64 *)(r1 + 8)
 assertion failed: r1 is pointer
 Code is unreachable after 1
```

* Make pre/postconditions more readable by displaying singleton types as strings instead of numbers, and by updating variable names to be more readable by developers.  (I have some ideas for a shorter form in the future that might be even easier to follow, but this is sufficient for now.)  Example:
```
{r10.value=[512, +oo], r10.offset=[512], r10.type=stack_pointer, packet_size=[0, 65534], meta_offset=[0], r0.type=number, r2.offset=[1, 512], r3.type=number, r1.value=[0], r3.value=[1], r1.type=number, r2.type=stack_pointer
 }
```

* Since all warnings are treated as errors as far as failing verification, call them "errors" in the output to avoid confusion

The change to print the failing instruction also resulted in moving prepare_cfg inside the timed_execution portion, which is also needed in order to get a true apples-to-apples comparison vs the Linux verifier.  This is because the prevail verifier requires conversion to cfg where linux does not, so the conversion has to be counted against the overall time to verify a set of instructions.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>