### PR TITLE
Improve performance of boost install during windows CI pass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,6 @@ jobs:
 
       - name: Build
         run: |
-          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
-          (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
-          Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
-          $env:BOOST_ROOT="C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
           mkdir build
           cmake -B build
           cmake --build build -j $(nproc) --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,14 +11,21 @@ endif ()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
     "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  find_package(Boost REQUIRED)
   set(CMAKE_CXX_STANDARD 17)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  find_program(NUGET nuget)
+  if (NOT NUGET)
+    message("ERROR: You must first install nuget.exe from https://www.nuget.org/downloads")
+  else ()
+    exec_program(${NUGET} ARGS install "Boost" -Version 1.75.0 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)
+  endif()
+  set(Boost_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/packages/boost/lib/native/include)
+
   # MSVC's C++17 standard option doesn't actually support all the C++17
   # features we use, but its "latest" option does.  However, cmake can't
   # deal with that here, so we set it below.
-endif()
-
-find_package(Boost REQUIRED)
+endif ()
 
 include_directories(./external)
 include_directories(./src)
@@ -63,6 +70,8 @@ target_compile_options(ebpfverifier PRIVATE ${COMMON_FLAGS})
 target_compile_options(ebpfverifier PUBLIC "$<$<CONFIG:DEBUG>:${DEBUG_FLAGS}>")
 target_compile_options(ebpfverifier PUBLIC "$<$<CONFIG:RELEASE>:${RELEASE_FLAGS}>")
 target_compile_options(ebpfverifier PUBLIC "$<$<CONFIG:SANITIZE>:${SANITIZE_FLAGS}>")
+
+set_property(TARGET ebpfverifier PROPERTY VS_PACKAGE_REFERENCES "Boost_1.75.5")
 
 # CMake derives a Visual Studio project GUID from the file path but can be overridden via a property
 # (see https://gitlab.kitware.com/cmake/cmake/-/commit/c85367f4).  Using a non-constant GUID


### PR DESCRIPTION
Install boost using a nuget package, which seems to be a couple of minutes faster than the previous method.

Fixes #203

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>