### PR TITLE
    Make wronghelper.o fail unmarshal()

### DIFF
--- a/src/asm_unmarshal.cpp
+++ b/src/asm_unmarshal.cpp
@@ -428,9 +428,10 @@ struct Unmarshaller {
     }
 };
 
-std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog, const ebpf_platform_t* platform, vector<vector<string>>& notes) {
+std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog, vector<vector<string>>& notes) {
+    global_program_info = raw_prog.info;
     try {
-        return Unmarshaller{notes,platform}.unmarshal(raw_prog.prog);
+        return Unmarshaller{notes, raw_prog.info.platform}.unmarshal(raw_prog.prog);
     } catch (InvalidInstruction& arg) {
         std::ostringstream ss;
         ss << arg.pc << ": " << arg.what() << "\n";
@@ -438,7 +439,7 @@ std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog,
     }
 }
 
-std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog, const ebpf_platform_t* platform) {
+std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog) {
     vector<vector<string>> notes;
-    return unmarshal(raw_prog, platform, notes);
+    return unmarshal(raw_prog, notes);
 }

--- a/src/asm_unmarshal.hpp
+++ b/src/asm_unmarshal.hpp
@@ -16,9 +16,8 @@
  *  of Instructions.
  *
  *  \param raw_prog is the input program to parse.
- *  \param platform is the platform on which the instructions are intended to run.
  *  \param notes is where errors and warnings are written to.
  *  \return a sequence of instruction if successful, an error string otherwise.
  */
-std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog, const ebpf_platform_t* platform, std::vector<std::vector<std::string>>& notes);
-std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog, const ebpf_platform_t* platform);
+std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog, std::vector<std::vector<std::string>>& notes);
+std::variant<InstructionSeq, std::string> unmarshal(const raw_program& raw_prog);

--- a/src/helpers.hpp
+++ b/src/helpers.hpp
@@ -31,4 +31,7 @@ struct EbpfHelperPrototype {
 
     // Arguments are passed in registers R1 to R5.
     EbpfHelperArgumentType argument_type[5];
+
+    // If R1 holds a context, then this holds a pointer to the context descriptor.
+    const EbpfContextDescriptor* context_descriptor;
 };

--- a/src/linux/gpl/spec_prototypes.cpp
+++ b/src/linux/gpl/spec_prototypes.cpp
@@ -1,4 +1,20 @@
 #include "platform.hpp"
+#include "spec_type_descriptors.hpp"
+
+const EbpfContextDescriptor g_sk_buff = sk_buff;
+const EbpfContextDescriptor g_xdp_md = xdp_md;
+const EbpfContextDescriptor g_sk_msg_md = sk_msg_md;
+const EbpfContextDescriptor g_unspec_descr = unspec_descr;
+const EbpfContextDescriptor g_cgroup_dev_descr = cgroup_dev_descr;
+const EbpfContextDescriptor g_kprobe_descr = kprobe_descr;
+const EbpfContextDescriptor g_tracepoint_descr = tracepoint_descr;
+const EbpfContextDescriptor g_perf_event_descr = perf_event_descr;
+const EbpfContextDescriptor g_cgroup_sock_descr = cgroup_sock_descr;
+const EbpfContextDescriptor g_sock_ops_descr = sock_ops_descr;
+
+// eBPF helpers are documented at the following links:
+// https://github.com/iovisor/bpf-docs/blob/master/bpf_helpers.rst
+// https://www.man7.org/linux/man-pages/man7/bpf-helpers.7.html
 
 static const struct EbpfHelperPrototype bpf_unspec_proto = {
     .name = "unspec",
@@ -315,6 +331,7 @@ static const struct EbpfHelperPrototype bpf_perf_prog_read_value_proto = {
         EbpfHelperArgumentType::PTR_TO_UNINIT_MEM,
         EbpfHelperArgumentType::CONST_SIZE,
     },
+    .context_descriptor = &g_perf_event_descr
 };
 
 // static const struct EbpfHelperPrototype bpf_perf_event_output_proto_raw_tp = {
@@ -521,6 +538,7 @@ static const struct EbpfHelperPrototype bpf_sock_map_update_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::DONTCARE,
     },
+    .context_descriptor = &g_sock_ops_descr
 };
 
 static const struct EbpfHelperPrototype bpf_sock_hash_update_proto = {
@@ -535,6 +553,7 @@ static const struct EbpfHelperPrototype bpf_sock_hash_update_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::DONTCARE,
     },
+    .context_descriptor = &g_sock_ops_descr
 };
 
 /*
@@ -643,6 +662,7 @@ static const struct EbpfHelperPrototype bpf_skb_store_bytes_proto = {
         EbpfHelperArgumentType::CONST_SIZE,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -674,6 +694,7 @@ static const struct EbpfHelperPrototype bpf_skb_load_bytes_proto = {
         EbpfHelperArgumentType::PTR_TO_UNINIT_MEM,
         EbpfHelperArgumentType::CONST_SIZE,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -711,6 +732,7 @@ static const struct EbpfHelperPrototype bpf_skb_load_bytes_relative_proto = {
         EbpfHelperArgumentType::CONST_SIZE,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 static const struct EbpfHelperPrototype bpf_skb_pull_data_proto = {
@@ -722,6 +744,7 @@ static const struct EbpfHelperPrototype bpf_skb_pull_data_proto = {
         EbpfHelperArgumentType::PTR_TO_CTX,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 // static const struct EbpfHelperPrototype sk_skb_pull_data_proto = {
@@ -757,6 +780,7 @@ static const struct EbpfHelperPrototype bpf_l3_csum_replace_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -783,6 +807,7 @@ static const struct EbpfHelperPrototype bpf_l4_csum_replace_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -818,6 +843,7 @@ static const struct EbpfHelperPrototype bpf_csum_update_proto = {
         EbpfHelperArgumentType::PTR_TO_CTX,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 static const struct EbpfHelperPrototype bpf_clone_redirect_proto = {
@@ -830,6 +856,7 @@ static const struct EbpfHelperPrototype bpf_clone_redirect_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_redirect_proto = {
     .name = "redirect",
@@ -852,6 +879,7 @@ static const struct EbpfHelperPrototype bpf_sk_redirect_hash_proto = {
         EbpfHelperArgumentType::PTR_TO_MAP_KEY,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_sk_redirect_map_proto = {
     .name = "sk_redirect_map",
@@ -864,6 +892,7 @@ static const struct EbpfHelperPrototype bpf_sk_redirect_map_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_msg_redirect_hash_proto = {
     .name = "msg_redirect_hash",
@@ -876,6 +905,7 @@ static const struct EbpfHelperPrototype bpf_msg_redirect_hash_proto = {
         EbpfHelperArgumentType::PTR_TO_MAP_KEY,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_msg_md
 };
 static const struct EbpfHelperPrototype bpf_msg_redirect_map_proto = {
     .name = "msg_redirect_map",
@@ -888,6 +918,7 @@ static const struct EbpfHelperPrototype bpf_msg_redirect_map_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_msg_md
 };
 static const struct EbpfHelperPrototype bpf_msg_apply_bytes_proto = {
     .name = "msg_apply_bytes",
@@ -898,6 +929,7 @@ static const struct EbpfHelperPrototype bpf_msg_apply_bytes_proto = {
         EbpfHelperArgumentType::PTR_TO_CTX,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_msg_md
 };
 static const struct EbpfHelperPrototype bpf_msg_cork_bytes_proto = {
     .name = "msg_cork_bytes",
@@ -908,6 +940,7 @@ static const struct EbpfHelperPrototype bpf_msg_cork_bytes_proto = {
         EbpfHelperArgumentType::PTR_TO_CTX,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_msg_md
 };
 static const struct EbpfHelperPrototype bpf_msg_pull_data_proto = {
     .name = "msg_pull_data",
@@ -920,6 +953,7 @@ static const struct EbpfHelperPrototype bpf_msg_pull_data_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_msg_md
 };
 static const struct EbpfHelperPrototype bpf_get_cgroup_classid_proto = {
     .name = "get_cgroup_classid",
@@ -927,6 +961,7 @@ static const struct EbpfHelperPrototype bpf_get_cgroup_classid_proto = {
     //.gpl_only   = false,
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = { EbpfHelperArgumentType::PTR_TO_CTX, },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_get_route_realm_proto = {
     .name = "get_route_realm",
@@ -934,6 +969,7 @@ static const struct EbpfHelperPrototype bpf_get_route_realm_proto = {
     //.gpl_only   = false,
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = { EbpfHelperArgumentType::PTR_TO_CTX, },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_get_hash_recalc_proto = {
     .name = "get_hash_recalc",
@@ -943,6 +979,7 @@ static const struct EbpfHelperPrototype bpf_get_hash_recalc_proto = {
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
     },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_set_hash_invalid_proto = {
     .name = "set_hash_invalid",
@@ -952,6 +989,7 @@ static const struct EbpfHelperPrototype bpf_set_hash_invalid_proto = {
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
     },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_set_hash_proto = {
     .name = "set_hash",
@@ -962,6 +1000,7 @@ static const struct EbpfHelperPrototype bpf_set_hash_proto = {
         EbpfHelperArgumentType::PTR_TO_CTX,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_skb_vlan_push_proto = {
     .name = "skb_vlan_push",
@@ -973,6 +1012,7 @@ static const struct EbpfHelperPrototype bpf_skb_vlan_push_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_skb_vlan_pop_proto = {
     .name = "skb_vlan_pop",
@@ -982,6 +1022,7 @@ static const struct EbpfHelperPrototype bpf_skb_vlan_pop_proto = {
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -1005,6 +1046,7 @@ static const struct EbpfHelperPrototype bpf_skb_change_proto_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -1023,6 +1065,7 @@ static const struct EbpfHelperPrototype bpf_skb_change_type_proto = {
         EbpfHelperArgumentType::PTR_TO_CTX,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -1045,6 +1088,7 @@ static const struct EbpfHelperPrototype bpf_skb_adjust_room_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -1066,6 +1110,7 @@ static const struct EbpfHelperPrototype bpf_skb_change_tail_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 // static const struct EbpfHelperPrototype sk_skb_change_tail_proto = {
@@ -1110,6 +1155,7 @@ static const struct EbpfHelperPrototype bpf_skb_change_head_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 // static const struct EbpfHelperPrototype sk_skb_change_head_proto = {
@@ -1132,6 +1178,7 @@ static const struct EbpfHelperPrototype bpf_xdp_adjust_head_proto = {
         EbpfHelperArgumentType::PTR_TO_CTX,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_xdp_descr
 };
 
 static const struct EbpfHelperPrototype bpf_xdp_adjust_tail_proto = {
@@ -1143,6 +1190,7 @@ static const struct EbpfHelperPrototype bpf_xdp_adjust_tail_proto = {
         EbpfHelperArgumentType::PTR_TO_CTX,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_xdp_descr
 };
 
 static const struct EbpfHelperPrototype bpf_xdp_adjust_meta_proto = {
@@ -1154,6 +1202,7 @@ static const struct EbpfHelperPrototype bpf_xdp_adjust_meta_proto = {
         EbpfHelperArgumentType::PTR_TO_CTX,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_xdp_descr
 };
 
 // static const struct EbpfHelperPrototype bpf_xdp_redirect_proto = {
@@ -1213,6 +1262,7 @@ static const struct EbpfHelperPrototype bpf_skb_get_tunnel_key_proto = {
         EbpfHelperArgumentType::CONST_SIZE,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -1233,6 +1283,7 @@ static const struct EbpfHelperPrototype bpf_skb_get_tunnel_opt_proto = {
         EbpfHelperArgumentType::PTR_TO_UNINIT_MEM,
         EbpfHelperArgumentType::CONST_SIZE,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -1255,6 +1306,7 @@ static const struct EbpfHelperPrototype bpf_skb_set_tunnel_key_proto = {
         EbpfHelperArgumentType::CONST_SIZE,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -1275,6 +1327,7 @@ static const struct EbpfHelperPrototype bpf_skb_set_tunnel_opt_proto = {
         EbpfHelperArgumentType::PTR_TO_MEM,
         EbpfHelperArgumentType::CONST_SIZE,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 /*
@@ -1298,6 +1351,7 @@ static const struct EbpfHelperPrototype bpf_skb_under_cgroup_proto = {
         EbpfHelperArgumentType::PTR_TO_MAP,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 static const struct EbpfHelperPrototype bpf_skb_cgroup_id_proto = {
@@ -1308,6 +1362,7 @@ static const struct EbpfHelperPrototype bpf_skb_cgroup_id_proto = {
     .argument_type = {
         EbpfHelperArgumentType::PTR_TO_CTX,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 // static const struct EbpfHelperPrototype bpf_xdp_event_output_proto = {
@@ -1330,6 +1385,7 @@ static const struct EbpfHelperPrototype bpf_get_socket_cookie_proto = {
     //.gpl_only   = false,
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = { EbpfHelperArgumentType::PTR_TO_CTX, },
+    .context_descriptor = &g_sk_buff
 };
 
 static const struct EbpfHelperPrototype bpf_get_socket_uid_proto = {
@@ -1338,6 +1394,7 @@ static const struct EbpfHelperPrototype bpf_get_socket_uid_proto = {
     //.gpl_only   = false,
     .return_type = EbpfHelperReturnType::INTEGER,
     .argument_type = { EbpfHelperArgumentType::PTR_TO_CTX, },
+    .context_descriptor = &g_sk_buff
 };
 
 static const struct EbpfHelperPrototype bpf_setsockopt_proto = {
@@ -1388,6 +1445,7 @@ static const struct EbpfHelperPrototype bpf_sock_ops_cb_flags_set_proto = {
         EbpfHelperArgumentType::PTR_TO_CTX,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sock_ops_descr
 };
 static const struct EbpfHelperPrototype bpf_bind_proto = {
     .name = "bind",
@@ -1430,6 +1488,7 @@ static const struct EbpfHelperPrototype bpf_skb_get_xfrm_state_proto = {
         EbpfHelperArgumentType::CONST_SIZE,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 
 static const struct EbpfHelperPrototype bpf_xdp_fib_lookup_proto = {
@@ -1460,15 +1519,16 @@ static const struct EbpfHelperPrototype bpf_xdp_fib_lookup_proto = {
 
 static const struct EbpfHelperPrototype bpf_lwt_push_encap_proto = {
     .name = "lwt_push_encap",
-   //.func		= bpf_lwt_push_encap,
-   //.gpl_only	= false,
-   .return_type = EbpfHelperReturnType::INTEGER,
-   .argument_type = {
-       EbpfHelperArgumentType::PTR_TO_CTX,
-       EbpfHelperArgumentType::ANYTHING,
-       EbpfHelperArgumentType::PTR_TO_MEM,
-       EbpfHelperArgumentType::CONST_SIZE
-   },
+    //.func		= bpf_lwt_push_encap,
+    //.gpl_only	= false,
+    .return_type = EbpfHelperReturnType::INTEGER,
+    .argument_type = {
+        EbpfHelperArgumentType::PTR_TO_CTX,
+        EbpfHelperArgumentType::ANYTHING,
+        EbpfHelperArgumentType::PTR_TO_MEM,
+        EbpfHelperArgumentType::CONST_SIZE
+    },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_lwt_seg6_store_bytes_proto = {
     .name = "lwt_seg6_store_bytes",
@@ -1481,6 +1541,7 @@ static const struct EbpfHelperPrototype bpf_lwt_seg6_store_bytes_proto = {
         EbpfHelperArgumentType::PTR_TO_MEM,
         EbpfHelperArgumentType::CONST_SIZE
     },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_lwt_seg6_action_proto = {
     .name = "lwt_seg6_action",
@@ -1493,6 +1554,7 @@ static const struct EbpfHelperPrototype bpf_lwt_seg6_action_proto = {
         EbpfHelperArgumentType::PTR_TO_MEM,
         EbpfHelperArgumentType::CONST_SIZE
     },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_lwt_seg6_adjust_srh_proto = {
     .name = "lwt_seg6_adjust_srh",
@@ -1504,6 +1566,7 @@ static const struct EbpfHelperPrototype bpf_lwt_seg6_adjust_srh_proto = {
         EbpfHelperArgumentType::ANYTHING,
         EbpfHelperArgumentType::ANYTHING,
     },
+    .context_descriptor = &g_sk_buff
 };
 static const struct EbpfHelperPrototype bpf_rc_repeat_proto = {
     .name = "rc_repeat", // without bpf_ originally
@@ -1993,7 +2056,17 @@ const struct EbpfHelperPrototype prototypes[81] = {
     FN(get_current_cgroup_id),
 };
 
-bool is_helper_usable_linux(unsigned int n) { return n < sizeof(prototypes) / sizeof(prototypes[0]) && n > 0; }
+bool is_helper_usable_linux(unsigned int n) {
+    if (n >= sizeof(prototypes) / sizeof(prototypes[0]) || n < 0)
+        return false;
+
+    // If the helper has a context_descriptor, it must match the hook's context_descriptor.
+    if ((prototypes[n].context_descriptor != nullptr) &&
+        (prototypes[n].context_descriptor != global_program_info.type.context_descriptor))
+        return false;
+
+    return true;
+}
 
 EbpfHelperPrototype get_helper_prototype_linux(unsigned int n) {
     if (!is_helper_usable_linux(n))

--- a/src/linux/gpl/spec_type_descriptors.hpp
+++ b/src/linux/gpl/spec_type_descriptors.hpp
@@ -33,11 +33,26 @@ constexpr EbpfContextDescriptor cgroup_dev_descr = {cgroup_dev_regions};
 constexpr EbpfContextDescriptor kprobe_descr = {kprobe_regions};
 constexpr EbpfContextDescriptor tracepoint_descr = {tracepoint_regions};
 constexpr EbpfContextDescriptor perf_event_descr = {perf_event_regions};
-constexpr EbpfContextDescriptor socket_filter_descr = sk_buff;
-constexpr EbpfContextDescriptor sched_descr = sk_buff;
-constexpr EbpfContextDescriptor xdp_descr = xdp_md;
-constexpr EbpfContextDescriptor lwt_xmit_descr = sk_buff;
-constexpr EbpfContextDescriptor lwt_inout_descr = sk_buff;
 constexpr EbpfContextDescriptor cgroup_sock_descr = {cgroup_sock_regions};
 constexpr EbpfContextDescriptor sock_ops_descr = {sock_ops_regions};
-constexpr EbpfContextDescriptor sk_skb_descr = sk_buff;
+
+extern const EbpfContextDescriptor g_sk_buff;
+extern const EbpfContextDescriptor g_xdp_md;
+extern const EbpfContextDescriptor g_sk_msg_md;
+extern const EbpfContextDescriptor g_unspec_descr;
+extern const EbpfContextDescriptor g_cgroup_dev_descr;
+extern const EbpfContextDescriptor g_kprobe_descr;
+extern const EbpfContextDescriptor g_tracepoint_descr;
+extern const EbpfContextDescriptor g_perf_event_descr;
+extern const EbpfContextDescriptor g_cgroup_sock_descr;
+extern const EbpfContextDescriptor g_sock_ops_descr;
+
+// The following all used the sk_buff descriptor and so the ctx is apparently interchangeable.
+#define g_socket_filter_descr g_sk_buff
+#define g_sched_descr g_sk_buff
+#define g_lwt_xmit_descr g_sk_buff
+#define g_lwt_inout_descr g_sk_buff
+#define g_sk_skb_descr g_sk_buff
+
+// And these were also interchangeable.
+#define g_xdp_descr g_xdp_md

--- a/src/linux/linux_platform.cpp
+++ b/src/linux/linux_platform.cpp
@@ -38,40 +38,40 @@ static int create_map_linux(uint32_t map_type, uint32_t key_size, uint32_t value
 #define COMMA ,
 
 const EbpfProgramType linux_socket_filter_program_type =
-    PTYPE("socket_filter", socket_filter_descr, BPF_PROG_TYPE_SOCKET_FILTER, {"socket"});
+    PTYPE("socket_filter", &g_socket_filter_descr, BPF_PROG_TYPE_SOCKET_FILTER, {"socket"});
 
 const EbpfProgramType linux_xdp_program_type =
-    PTYPE("xdp", xdp_descr, BPF_PROG_TYPE_XDP, {"xdp"});
+    PTYPE("xdp", &g_xdp_descr, BPF_PROG_TYPE_XDP, {"xdp"});
 
 const EbpfProgramType cilium_lxc_program_type =
-    PTYPE("lxc", sched_descr, BPF_PROG_TYPE_SOCKET_FILTER, {});
+    PTYPE("lxc", &g_sched_descr, BPF_PROG_TYPE_SOCKET_FILTER, {});
 
 const std::vector<EbpfProgramType> linux_program_types = {
-    PTYPE("unspec", unspec_descr, BPF_PROG_TYPE_UNSPEC, {}),
+    PTYPE("unspec", &g_unspec_descr, BPF_PROG_TYPE_UNSPEC, {}),
     linux_socket_filter_program_type,
     linux_xdp_program_type,
-    PTYPE("cgroup_device", cgroup_dev_descr, BPF_PROG_TYPE_CGROUP_DEVICE, {"cgroup/dev"}),
-    PTYPE("cgroup_skb", socket_filter_descr, BPF_PROG_TYPE_CGROUP_SKB, {"cgroup/skb"}),
-    PTYPE("cgroup_sock", cgroup_sock_descr, BPF_PROG_TYPE_CGROUP_SOCK, {"cgroup/sock"}),
-    PTYPE_PRIVILEGED("kprobe", kprobe_descr, BPF_PROG_TYPE_KPROBE, {"kprobe/" COMMA "kretprobe/"}),
-    PTYPE("lwt_in", lwt_inout_descr, BPF_PROG_TYPE_LWT_IN, {"lwt_in"}),
-    PTYPE("lwt_out", lwt_inout_descr, BPF_PROG_TYPE_LWT_OUT, {"lwt_out"}),
-    PTYPE("lwt_xmit", lwt_xmit_descr, BPF_PROG_TYPE_LWT_XMIT, {"lwt_xmit"}),
-    PTYPE("perf_event", perf_event_descr, BPF_PROG_TYPE_PERF_EVENT, {"perf_section" COMMA "perf_event"}),
-    PTYPE("sched_act", sched_descr, BPF_PROG_TYPE_SCHED_ACT, {"action"}),
-    PTYPE("sched_cls", sched_descr, BPF_PROG_TYPE_SCHED_CLS, {"classifier"}),
-    PTYPE("sk_skb", sk_skb_descr, BPF_PROG_TYPE_SK_SKB, {"sk_skb"}),
-    PTYPE("sock_ops", sock_ops_descr, BPF_PROG_TYPE_SOCK_OPS, {"sockops"}),
-    PTYPE("tracepoint", tracepoint_descr, BPF_PROG_TYPE_TRACEPOINT, {"tracepoint/"}),
+    PTYPE("cgroup_device", &g_cgroup_dev_descr, BPF_PROG_TYPE_CGROUP_DEVICE, {"cgroup/dev"}),
+    PTYPE("cgroup_skb", &g_socket_filter_descr, BPF_PROG_TYPE_CGROUP_SKB, {"cgroup/skb"}),
+    PTYPE("cgroup_sock", &g_cgroup_sock_descr, BPF_PROG_TYPE_CGROUP_SOCK, {"cgroup/sock"}),
+    PTYPE_PRIVILEGED("kprobe", &g_kprobe_descr, BPF_PROG_TYPE_KPROBE, {"kprobe/" COMMA "kretprobe/"}),
+    PTYPE("lwt_in", &g_lwt_inout_descr, BPF_PROG_TYPE_LWT_IN, {"lwt_in"}),
+    PTYPE("lwt_out", &g_lwt_inout_descr, BPF_PROG_TYPE_LWT_OUT, {"lwt_out"}),
+    PTYPE("lwt_xmit", &g_lwt_xmit_descr, BPF_PROG_TYPE_LWT_XMIT, {"lwt_xmit"}),
+    PTYPE("perf_event", &g_perf_event_descr, BPF_PROG_TYPE_PERF_EVENT, {"perf_section" COMMA "perf_event"}),
+    PTYPE("sched_act", &g_sched_descr, BPF_PROG_TYPE_SCHED_ACT, {"action"}),
+    PTYPE("sched_cls", &g_sched_descr, BPF_PROG_TYPE_SCHED_CLS, {"classifier"}),
+    PTYPE("sk_skb", &g_sk_skb_descr, BPF_PROG_TYPE_SK_SKB, {"sk_skb"}),
+    PTYPE("sock_ops", &g_sock_ops_descr, BPF_PROG_TYPE_SOCK_OPS, {"sockops"}),
+    PTYPE("tracepoint", &g_tracepoint_descr, BPF_PROG_TYPE_TRACEPOINT, {"tracepoint/"}),
 
     // The following types are currently mapped to the socket filter program
     // type but should be mapped to the relevant native linux program type
     // value.
-    PTYPE("sk_msg", sk_msg_md, BPF_PROG_TYPE_SOCKET_FILTER, {"sk_msg"}),
-    PTYPE("raw_tracepoint", tracepoint_descr, BPF_PROG_TYPE_SOCKET_FILTER, {"raw_tracepoint/"}),
-    PTYPE("cgroup_sock_addr", cgroup_sock_descr, BPF_PROG_TYPE_SOCKET_FILTER, {}),
-    PTYPE("lwt_seg6local", lwt_xmit_descr, BPF_PROG_TYPE_SOCKET_FILTER, {"lwt_seg6local"}),
-    PTYPE("lirc_mode2", sk_msg_md, BPF_PROG_TYPE_SOCKET_FILTER, {"lirc_mode2"}),
+    PTYPE("sk_msg", &g_sk_msg_md, BPF_PROG_TYPE_SOCKET_FILTER, {"sk_msg"}),
+    PTYPE("raw_tracepoint", &g_tracepoint_descr, BPF_PROG_TYPE_SOCKET_FILTER, {"raw_tracepoint/"}),
+    PTYPE("cgroup_sock_addr", &g_cgroup_sock_descr, BPF_PROG_TYPE_SOCKET_FILTER, {}),
+    PTYPE("lwt_seg6local", &g_lwt_xmit_descr, BPF_PROG_TYPE_SOCKET_FILTER, {"lwt_seg6local"}),
+    PTYPE("lirc_mode2", &g_sk_msg_md, BPF_PROG_TYPE_SOCKET_FILTER, {"lirc_mode2"}),
 };
 
 static EbpfProgramType get_program_type_linux(const std::string& section, const std::string& path) {

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
     raw_program raw_prog = raw_progs.back();
 
     // Convert the raw program section to a set of instructions.
-    std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog, &g_ebpf_platform_linux);
+    std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);
     if (std::holds_alternative<string>(prog_or_error)) {
         std::cout << "unmarshaling error at " << std::get<string>(prog_or_error) << "\n";
         return 1;

--- a/src/spec_type_descriptors.hpp
+++ b/src/spec_type_descriptors.hpp
@@ -35,7 +35,7 @@ struct EbpfContextDescriptor {
 
 struct EbpfProgramType {
     std::string name; // For ease of display, not used by the verifier.
-    EbpfContextDescriptor context_descriptor;
+    const EbpfContextDescriptor* context_descriptor;
     uint64_t platform_specific_data; // E.g., integer program type.
     std::vector<std::string> section_prefixes;
     bool is_privileged;

--- a/src/test/test_loop.cpp
+++ b/src/test/test_loop.cpp
@@ -25,7 +25,8 @@ TEST_CASE("Trivial loop: middle", "[sanity][loop]") {
         .check_termination=false
     };
     program_info info{
-        .platform = &g_ebpf_platform_linux
+        .platform = &g_ebpf_platform_linux,
+        .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")
     };
     bool pass = run_ebpf_analysis(std::cout, cfg, info, &options);
     REQUIRE(pass);

--- a/src/test/test_marshal.cpp
+++ b/src/test/test_marshal.cpp
@@ -7,7 +7,9 @@
 #include "asm_unmarshal.hpp"
 
 static void compare_marshal_unmarshal(const Instruction& ins, bool double_cmd = false) {
-    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", marshal(ins, 0), {}}, &g_ebpf_platform_linux));
+    program_info info{.platform = &g_ebpf_platform_linux,
+                      .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")};
+    InstructionSeq parsed = std::get<InstructionSeq>(unmarshal(raw_program{"", "", marshal(ins, 0), info}));
     REQUIRE(parsed.size() == 1);
     auto [_, single] = parsed.back();
     (void)_; // unused

--- a/src/test/test_termination.cpp
+++ b/src/test/test_termination.cpp
@@ -24,7 +24,8 @@ TEST_CASE("Trivial infinite loop", "[loop][termination]") {
         .check_termination = true,
     };
     program_info info{
-        .platform = &g_ebpf_platform_linux
+        .platform = &g_ebpf_platform_linux,
+        .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")
     };
     bool pass = run_ebpf_analysis(std::cout, cfg, info, &options);
     REQUIRE_FALSE(pass);
@@ -52,7 +53,8 @@ TEST_CASE("Trivial finite loop", "[loop][termination]") {
         .check_termination = true,
     };
     program_info info{
-        .platform = &g_ebpf_platform_linux
+        .platform = &g_ebpf_platform_linux,
+        .type = g_ebpf_platform_linux.get_program_type("unspec", "unspec")
     };
     bool pass = run_ebpf_analysis(std::cout, cfg, info, &options);
     REQUIRE(pass);


### PR DESCRIPTION
The basic idea is that it is up to the platform to determine whether a given helper ID is valid for a given program type.  This PR updates the Linux platform implementation to verify that the helper's ctx (if any) has the same context_descriptor as the program type.

The platform might still have further constraints that were not implemented before and this PR does not add.

Addresses issue #192

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>