### PR TITLE
Make ctxoffset.o sample fail validation

### DIFF
--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -62,8 +62,8 @@ class AssertExtractor {
                 break;
             case ArgSingle::Kind::PTR_TO_CTX:
                 res.emplace_back(TypeConstraint{arg.reg, TypeGroup::ctx});
-                // TODO: the kernel has some other conditions here -
-                //       maybe offset == 0
+                // Offset == 0 is enforced by having all changes to offset
+                // convert the Kind to a number.
                 break;
             }
         }

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -919,6 +919,7 @@ class ebpf_domain_t final {
         using namespace dsl_syntax;
 
         auto dst = reg_pack(bin.dst);
+        auto dtype = get_type(dst.type);
 
         if (std::holds_alternative<Imm>(bin.v)) {
             // dst += K
@@ -932,13 +933,19 @@ class ebpf_domain_t final {
                 if (imm == 0)
                     return;
                 add_overflow(dst.value, imm);
-                add(dst.offset, imm);
+                if (dtype == T_CTX)
+                    no_pointer(dst);
+                else
+                    add(dst.offset, imm);
                 break;
             case Bin::Op::SUB:
                 if (imm == 0)
                     return;
                 sub_overflow(dst.value, imm);
-                sub(dst.offset, imm);
+                if (dtype == T_CTX)
+                    no_pointer(dst);
+                else
+                    sub(dst.offset, imm);
                 break;
             case Bin::Op::MUL:
                 mul(dst.value, imm);

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -424,6 +424,7 @@ TEST_SECTION("raw_tracepoint/filler/sys_recvfrom_x")
 
 // Test some programs that ought to fail verification.
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
+TEST_SECTION_REJECT("build", "ctxoffset.o", "sockops")
 TEST_SECTION_REJECT("build", "badmapptr.o", "test")
 TEST_SECTION_REJECT("build", "exposeptr.o", ".text")
 TEST_SECTION_REJECT("build", "exposeptr2.o", ".text")


### PR DESCRIPTION
Doing arithmetic on a ctx should convert it to a number

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>