### PR TITLE
Make ctxoffset.o sample fail validation

### DIFF
--- a/src/asm_ostream.cpp
+++ b/src/asm_ostream.cpp
@@ -10,6 +10,7 @@
 #include "asm_syntax.hpp"
 #include "crab/cfg.hpp"
 #include "asm_ostream.hpp"
+#include "crab/variable.hpp"
 
 using std::optional;
 using std::string;
@@ -132,8 +133,13 @@ std::ostream& operator<<(std::ostream& os, ValidMapKeyValue const& a) {
               << "))";
 }
 
+std::ostream& operator<<(std::ostream& os, ZeroOffset const& a) {
+    return os << crab::variable_t::reg(crab::data_kind_t::offsets, a.reg.v) << " == 0";
+}
+
 std::ostream& operator<<(std::ostream& os, Comparable const& a) {
-    return os << "type(" << a.r1 << ") == type(" << a.r2 << ")";
+    return os << crab::variable_t::reg(crab::data_kind_t::types, a.r1.v) << " == "
+              << crab::variable_t::reg(crab::data_kind_t::types, a.r2.v);
 }
 
 std::ostream& operator<<(std::ostream& os, Addable const& a) {

--- a/src/asm_syntax.hpp
+++ b/src/asm_syntax.hpp
@@ -276,8 +276,13 @@ struct TypeConstraint {
     TypeGroup types;
 };
 
+/// Condition check whether something is a valid size.
+struct ZeroOffset {
+    Reg reg;
+};
+
 using AssertionConstraint =
-    std::variant<Comparable, Addable, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue, TypeConstraint>;
+    std::variant<Comparable, Addable, ValidAccess, ValidStore, ValidSize, ValidMapKeyValue, TypeConstraint, ZeroOffset>;
 
 struct Assert {
     AssertionConstraint cst;
@@ -354,6 +359,7 @@ DECLARE_EQ2(Addable, ptr, num)
 DECLARE_EQ2(ValidStore, mem, val)
 DECLARE_EQ4(ValidAccess, reg, offset, width, or_null)
 DECLARE_EQ3(ValidMapKeyValue, access_reg, map_fd_reg, key)
+DECLARE_EQ1(ZeroOffset, reg)
 DECLARE_EQ1(Assert, cst)
 
 }

--- a/src/assertions.cpp
+++ b/src/assertions.cpp
@@ -62,8 +62,7 @@ class AssertExtractor {
                 break;
             case ArgSingle::Kind::PTR_TO_CTX:
                 res.emplace_back(TypeConstraint{arg.reg, TypeGroup::ctx});
-                // TODO: the kernel has some other conditions here -
-                //       maybe offset == 0
+                res.emplace_back(ZeroOffset{arg.reg});
                 break;
             }
         }

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -640,6 +640,12 @@ class ebpf_domain_t final {
         }
     }
 
+    void operator()(const ZeroOffset& s) {
+        using namespace dsl_syntax;
+        auto reg = reg_pack(s.reg);
+        require(m_inv, reg.offset == 0, to_string(s));
+    }
+
     void operator()(Assert const& stmt) { std::visit(*this, stmt.cst); };
 
     void operator()(Packet const& a) {

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -424,6 +424,7 @@ TEST_SECTION("raw_tracepoint/filler/sys_recvfrom_x")
 
 // Test some programs that ought to fail verification.
 TEST_SECTION_REJECT("build", "badhelpercall.o", ".text")
+TEST_SECTION_REJECT("build", "ctxoffset.o", "sockops")
 TEST_SECTION_REJECT("build", "badmapptr.o", "test")
 TEST_SECTION_REJECT("build", "exposeptr.o", ".text")
 TEST_SECTION_REJECT("build", "exposeptr2.o", ".text")


### PR DESCRIPTION
Assert that ctx offset is 0

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>